### PR TITLE
Avg score

### DIFF
--- a/scripting/smartscramble.sp
+++ b/scripting/smartscramble.sp
@@ -138,6 +138,7 @@ public void OnPluginStart() {
 
 	PluginStartDebugSystem();
 	PluginStartScoringSystem();
+	PluginStartTeamBuilderSystem();
 	PluginStartBuddySystem();
 	PluginStartAutoScrambleSystem();
 

--- a/scripting/smartscramble/autoscramble.sp
+++ b/scripting/smartscramble/autoscramble.sp
@@ -104,7 +104,7 @@ void PluginStartAutoScrambleSystem() {
 	s_RoundWinStreak = s_ConVar_RoundWinStreak.IntValue;
 
 	s_ConVar_DominationLead = CreateConVar(
-		"ss_autoscramble_domination_lead", "10",
+		"ss_autoscramble_domination_lead", "8",
 		"Auto-scramble if the winning team has this many more dominations than the average dominations of all other teams. A value of 0 will disable this check.",
 		_,
 		true, 0.0
@@ -113,7 +113,7 @@ void PluginStartAutoScrambleSystem() {
 	s_DominationLead = s_ConVar_DominationLead.IntValue;
 
 	s_ConVar_FragRatio = CreateConVar(
-		"ss_autoscramble_frag_ratio", "2.0",
+		"ss_autoscramble_frag_ratio", "1.75",
 		"Auto-scramble if the winning team's frag ratio to the average of all other team frags is greater than or equal to this. A value of 0 will disable this check.",
 		_,
 		true, 0.0

--- a/scripting/smartscramble/team_builder.sp
+++ b/scripting/smartscramble/team_builder.sp
@@ -25,6 +25,28 @@
  * @param clientCount     Number of clients in the clients array.
  * @return                Number of unassigned buddies members of this team have.
  */
+ 
+ 
+ConVar g_ConVar_NewPlayerThreshold;
+float g_NewPlayerThreshold;
+ 
+void PluginStartTeamBuilderSystem() {
+	g_ConVar_NewPlayerThreshold = CreateConVar(
+		"ss_new_threshold", "300",
+		"The amount of time after joining where a player's effective score for scrambles incorporates the server's average score.",
+		_,
+		true, 0.0,
+		false, 2.0
+	);
+	
+	g_ConVar_NewPlayerThreshold.AddChangeHook(conVarChanged_NewPlayerThreshold);
+	
+}
+	
+static void conVarChanged_NewPlayerThreshold(ConVar convar, const char[] oldValue, const char[] newValue) {
+	g_NewPlayerThreshold = StringToFloat(newValue);
+}
+ 
 static int countTeamUnassignedBuddies(int team, int clients[MAXPLAYERS], int clientTeams[MAXPLAYERS], int clientCount) {
 	int count = 0;
 	for (int i = 0; i < clientCount; ++i) {
@@ -270,6 +292,23 @@ void BuildScrambleTeams(ScrambleMethod scrambleMethod, int clients[MAXPLAYERS], 
 	if (scrambleMethod != ScrambleMethod_Shuffle) {
 		for (int i = 0; i < clientCount; ++i) {
 			clientScores[i] = ScoreClient(clients[i]);
+		}
+		//only run the following for gamescore_time scoring
+		//doing so is a bandaid but it only needs to work with this scoring method for now
+		if (g_ScoreMethod == ScoreMethod_GameScore_Time) {
+			//get the average score of all clients
+			int scoreAvg = 0;
+			for (int i = 0; i < clientCount; ++i) {
+				scoreAvg += ScoreClient(clients[i]);
+				if (clientCount > 0) { //dunno if this check is actually needed but i'd rather not find out
+					scoreAvg /= clientCount;
+				}
+			}
+			for (int i = 0; i < clientCount; ++i) {
+				if (GetClientCurrentPlayTime(clients[i]) < g_ConVar_NewPlayerThreshold) {
+				clientScores[i] = scoreAvg;
+				}
+			}
 		}
 	}
 

--- a/scripting/smartscramble/team_builder.sp
+++ b/scripting/smartscramble/team_builder.sp
@@ -305,7 +305,7 @@ void BuildScrambleTeams(ScrambleMethod scrambleMethod, int clients[MAXPLAYERS], 
 				}
 			}
 			for (int i = 0; i < clientCount; ++i) {
-				if (GetClientCurrentPlayTime(clients[i]) < g_ConVar_NewPlayerThreshold) {
+				if (GetClientCurrentPlayTime(clients[i]) < g_NewPlayerThreshold) {
 				clientScores[i] = scoreAvg;
 				}
 			}


### PR DESCRIPTION
can you believe it, guys? 2.2! just a week away!
- when scrambling teams, plugin detects if a player has been connected for less than an amount of time specified by a cvar (default: 300 seconds) and, if so, treats them as though their score were the server average for the current scramble
- lowered default thresholds to autoscramble for domination lead (10 > 8) or frag ratio (2.0 > 1.75)